### PR TITLE
[Day01] 응용 실습 - 김병조

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/build.gradle
+++ b/build.gradle
@@ -39,4 +39,10 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-web')
     // 테스트
     testImplementation('org.springframework.boot:spring-boot-starter-test')
+
+    // Lombok 설정
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/src/main/java/com/jojoldu/book/springboot/web/HelloController.java
+++ b/src/main/java/com/jojoldu/book/springboot/web/HelloController.java
@@ -6,16 +6,18 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
-public class HelloController {
-
+public class HelloController
+{
     @GetMapping("/hello")
-    public String hello() {
+    public String hello()
+    {
         return "hello";
     }
 
     @GetMapping("/hello/dto")
     public HelloResponseDto helloDto(@RequestParam("name") String name, //
-                                     @RequestParam("amount") int amount) {
+                                     @RequestParam("amount") int amount)
+    {
         return new HelloResponseDto(name, amount);
     }
 }

--- a/src/main/java/com/jojoldu/book/springboot/web/HelloController.java
+++ b/src/main/java/com/jojoldu/book/springboot/web/HelloController.java
@@ -1,7 +1,9 @@
 package com.jojoldu.book.springboot.web;
+import com.jojoldu.book.springboot.web.dto.HelloResponseDto;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 public class HelloController {
@@ -9,5 +11,11 @@ public class HelloController {
     @GetMapping("/hello")
     public String hello() {
         return "hello";
+    }
+
+    @GetMapping("/hello/dto")
+    public HelloResponseDto helloDto(@RequestParam("name") String name, //
+                                     @RequestParam("amount") int amount) {
+        return new HelloResponseDto(name, amount);
     }
 }

--- a/src/main/java/com/jojoldu/book/springboot/web/dto/HelloResponseDto.java
+++ b/src/main/java/com/jojoldu/book/springboot/web/dto/HelloResponseDto.java
@@ -1,0 +1,13 @@
+package com.jojoldu.book.springboot.web.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class HelloResponseDto {
+
+    private final String name;
+    private final int amount;
+
+}

--- a/src/main/java/com/jojoldu/book/springboot/web/practice/EchoController.java
+++ b/src/main/java/com/jojoldu/book/springboot/web/practice/EchoController.java
@@ -1,0 +1,15 @@
+package com.jojoldu.book.springboot.web.practice;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+
+public class EchoController {
+    // TODO: GET /echo/{message} 매핑
+    @GetMapping("/echo/{message}")
+    public String echo(@PathVariable("message") String message) {
+        return new StringBuilder(message).reverse().toString();
+    }
+}

--- a/src/main/java/com/jojoldu/book/springboot/web/practice/HealthController.java
+++ b/src/main/java/com/jojoldu/book/springboot/web/practice/HealthController.java
@@ -1,4 +1,18 @@
 package com.jojoldu.book.springboot.web.practice;
 
-public class HealthController {
+
+import com.jojoldu.book.springboot.web.practice.dto.HealthResponseDto;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController
+{
+    @GetMapping("/health")
+    public HealthResponseDto health()
+    {
+        return new HealthResponseDto("OK", LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/jojoldu/book/springboot/web/practice/HealthController.java
+++ b/src/main/java/com/jojoldu/book/springboot/web/practice/HealthController.java
@@ -1,0 +1,4 @@
+package com.jojoldu.book.springboot.web.practice;
+
+public class HealthController {
+}

--- a/src/main/java/com/jojoldu/book/springboot/web/practice/dto/CalculatorDto.java
+++ b/src/main/java/com/jojoldu/book/springboot/web/practice/dto/CalculatorDto.java
@@ -1,0 +1,24 @@
+package com.jojoldu.book.springboot.web.practice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+
+public class CalculatorDto
+{
+    private int a;
+    private int b;
+
+    public int add()
+    {
+        return a + b;
+    }
+    public int subtract()
+    {
+        return a - b;
+    }
+}

--- a/src/main/java/com/jojoldu/book/springboot/web/practice/dto/HealthResponseDto.java
+++ b/src/main/java/com/jojoldu/book/springboot/web/practice/dto/HealthResponseDto.java
@@ -1,0 +1,14 @@
+package com.jojoldu.book.springboot.web.practice.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+
+public class HealthResponseDto {
+    private final String status;
+    private final LocalDateTime timestamp;
+    // TODO: timestamp 필드 (LocalDateTime 타입)를 추가하세요
+}

--- a/src/test/java/com/jojoldu/book/springboot/web/HelloControllerTest.java
+++ b/src/test/java/com/jojoldu/book/springboot/web/HelloControllerTest.java
@@ -8,8 +8,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.hamcrest.Matchers.is;
 @WebMvcTest(controllers = HelloController.class)
+//@WebMvcTest()
 public class HelloControllerTest {
 
     @Autowired
@@ -23,4 +25,18 @@ public class HelloControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(hello));
     }
+    @Test
+    public void return_helloDto() throws Exception {
+        String name = "hello";
+        int amount = 1000;
+
+        mvc.perform(
+                        get("/hello/dto")
+                                .param("name", name)
+                                .param("amount", String.valueOf(amount)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is(name)))
+                .andExpect(jsonPath("$.amount", is(amount)));
+    }
+
 }

--- a/src/test/java/com/jojoldu/book/springboot/web/dto/HelloResponseDtoTest.java
+++ b/src/test/java/com/jojoldu/book/springboot/web/dto/HelloResponseDtoTest.java
@@ -1,0 +1,22 @@
+package com.jojoldu.book.springboot.web.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HelloResponseDtoTest {
+
+    @Test
+    public void 롬복_기능_테스트() {
+        //given
+        String name = "test";
+        int amount = 1000;
+
+        //when
+        HelloResponseDto dto = new HelloResponseDto(name, amount);
+
+        //then
+        assertThat(dto.getName()).isEqualTo(name);
+        assertThat(dto.getAmount()).isEqualTo(amount);
+    }
+}

--- a/src/test/java/com/jojoldu/book/springboot/web/practice/EchoControllerTest.java
+++ b/src/test/java/com/jojoldu/book/springboot/web/practice/EchoControllerTest.java
@@ -1,0 +1,24 @@
+package com.jojoldu.book.springboot.web.practice;
+
+import org.junit.jupiter.api.Test;
+// TODO: 필요한 import (Autowired, WebMvcTest, MockMvc, get, status, content)
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = EchoController.class)
+
+public class EchoControllerTest {
+    @Autowired
+    private MockMvc mvc;
+    @Test
+    public void spring을_거꾸로_뒤집으면_gnirps() throws Exception {
+        // TODO: GET /echo/spring 요청 → status 200 → content "gnirps" 검증
+        mvc.perform(get("/echo/spring"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("gnirps"));
+    }
+}

--- a/src/test/java/com/jojoldu/book/springboot/web/practice/HealthControllerTest.java
+++ b/src/test/java/com/jojoldu/book/springboot/web/practice/HealthControllerTest.java
@@ -1,0 +1,4 @@
+package com.jojoldu.book.springboot.web.practice;
+
+public class HealthControllerTest {
+}

--- a/src/test/java/com/jojoldu/book/springboot/web/practice/HealthControllerTest.java
+++ b/src/test/java/com/jojoldu/book/springboot/web/practice/HealthControllerTest.java
@@ -1,4 +1,29 @@
 package com.jojoldu.book.springboot.web.practice;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.*;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(HealthController.class)
 public class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    public void return_health() throws Exception {
+        mvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.timestamp").isNotEmpty());
+    }
 }

--- a/src/test/java/com/jojoldu/book/springboot/web/practice/dto/CalculatorDtoTest.java
+++ b/src/test/java/com/jojoldu/book/springboot/web/practice/dto/CalculatorDtoTest.java
@@ -1,0 +1,36 @@
+package com.jojoldu.book.springboot.web.practice.dto;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CalculatorDtoTest
+{
+    @Test
+    public void add_메서드_검증()
+    {
+        // given
+        CalculatorDto dto = CalculatorDto.builder()
+                .a(10)
+                .b(3)
+                .build();
+        // when
+        int result = dto.add();
+        // then
+        // TODO: result가 13인지 검증
+        assertThat(result).isEqualTo(13);
+    }
+    // TODO: subtract_메서드_검증 테스트도 추가
+    @Test
+    public void subtract_메서드_검증()
+    {
+        // given
+        CalculatorDto dto = CalculatorDto.builder()
+                .a(10)
+                .b(3)
+                .build();
+        // when
+        int result = dto.subtract();
+        // then
+        assertThat(result).isEqualTo(7);
+    }
+}

--- a/src/test/java/com/jojoldu/book/springboot/web/practice/dto/HealthResponseDtoTest.java
+++ b/src/test/java/com/jojoldu/book/springboot/web/practice/dto/HealthResponseDtoTest.java
@@ -1,0 +1,4 @@
+package com.jojoldu.book.springboot.web.practice.dto;
+
+public class HealthResponseDtoTest {
+}


### PR DESCRIPTION
## 선택한 응용 과제

- [x] A. /health 엔드포인트

- [x] B. CalculatorDto + @Builder

- [x] C. /echo/{message}

## 단계별 커밋

- feat(practice): [HealthResponseDto 추가](https://github.com/TNMY1110/freelec-springboot2-webservice-2026/pull/2/changes/c177ae41c6514483eb54849e268be3413dddafe6)

- feat(practice): [/health 엔드포인트 추가](https://github.com/TNMY1110/freelec-springboot2-webservice-2026/pull/2/changes/c3bd756ab3f2bd30ce4869c871686188e99f3deb)

- test(practice): [HealthController 응답 검증](https://github.com/TNMY1110/freelec-springboot2-webservice-2026/pull/2/changes/4eb3fd5f320f15b7445fd645677345d36e00abaf)

- feat(practice): [CalculatorDto + @Builder](https://github.com/TNMY1110/freelec-springboot2-webservice-2026/pull/2/changes/7a58006e98706b508535c0d1d9c434ea894ef52e)

- test(practice): [CalculatorDto add/subtract 단위 테스트](https://github.com/TNMY1110/freelec-springboot2-webservice-2026/pull/2/changes/313e51121edf2f611e8163d8924bb37fa01b43f5)

- feat(practice): [/echo/{message} 엔드포인트 추가](https://github.com/TNMY1110/freelec-springboot2-webservice-2026/pull/2/changes/9edf4e1c1d14b0b6dc02058754e4e061cd67e834)

- test(practice): [EchoController 거꾸로 뒤집기 검증](https://github.com/TNMY1110/freelec-springboot2-webservice-2026/pull/2/changes/17a56a98c5b311b2f537761fadf424701f85b1a1)



## 어려웠던 점
- 어노테이션/클래스를 쓸 때마다 import를 직접 추가해야 한다는 것
- 롬복 어노테이션 구분 각각 언제 써야 하는지

## 학습한 점
- 롬복 어노테이션 역할 구분

어노테이션 | 생성되는 생성자 | 예시
-- | -- | --
@NoArgsConstructor | 인자 없는 생성자 | new Dto()
@AllArgsConstructor | 모든 필드를 인자로 받는 생성자 | new Dto(name, amount)
@RequiredArgsConstructor | final 또는 @NonNull 필드만 인자로 받는 생성자 | final 필드만 받음

어노테이션 | 역할
-- | --
@Getter | 모든 필드의 getter 자동 생성 (getName(), getAmount())
@Setter | 모든 필드의 setter 자동 생성
@Builder | 빌더 패턴 사용 가능 (Dto.builder().name("x").build())
@ToString | toString() 자동 생성


- 순수 단위 테스트와 웹 계층 테스트
- MockMvc로 HTTP 요청/응답 검증하는 방법 - status().isOk(), content().string(), jsonPath()

